### PR TITLE
fix:make ProfilePage reload experience good

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -3,25 +3,27 @@
     :class="{ 'setting-layout-header': isSettingLayout }"
     v-show="!isLoading"
   >
-    <div class="arrow" v-show="isShowArrow" @click="handleBackArrow">
-      <svg
-        width="17"
-        height="14"
-        viewBox="0 0 17 14"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M16 5.99988H3.41399L7.70699 1.70687C8.09699 1.31687 8.09699 0.683875 7.70699 0.292875C7.31699 -0.0981249 6.68399 -0.0971249 6.29299 0.292875L0.292988 6.29288C-0.0970117 6.68288 -0.0970117 7.31588 0.292988 7.70687L6.29299 13.7069C6.48799 13.9019 6.74299 13.9999 6.99999 13.9999C7.25699 13.9999 7.51199 13.9019 7.70699 13.7069C8.09699 13.3169 8.09699 12.6839 7.70699 12.2929L3.41399 7.99988H16C16.553 7.99988 17 7.55288 17 6.99988C17 6.44688 16.553 5.99988 16 5.99988Z"
-          fill="black"
-        />
-      </svg>
+    <div v-show="isHeaderReady" class="header-content">
+      <div class="arrow" v-show="isShowArrow" @click="handleBackArrow">
+        <svg
+          width="17"
+          height="14"
+          viewBox="0 0 17 14"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 5.99988H3.41399L7.70699 1.70687C8.09699 1.31687 8.09699 0.683875 7.70699 0.292875C7.31699 -0.0981249 6.68399 -0.0971249 6.29299 0.292875L0.292988 6.29288C-0.0970117 6.68288 -0.0970117 7.31588 0.292988 7.70687L6.29299 13.7069C6.48799 13.9019 6.74299 13.9999 6.99999 13.9999C7.25699 13.9999 7.51199 13.9019 7.70699 13.7069C8.09699 13.3169 8.09699 12.6839 7.70699 12.2929L3.41399 7.99988H16C16.553 7.99988 17 7.55288 17 6.99988C17 6.44688 16.553 5.99988 16 5.99988Z"
+            fill="black"
+          />
+        </svg>
+      </div>
+      <div v-if="isUser" class="user-wrapper">
+        <div class="name">{{ userTitle }}</div>
+        <div class="info">{{ userTweetCount }}推文</div>
+      </div>
+      <span v-else class="title">{{ title }}</span>
     </div>
-    <div v-if="isUser" class="user-wrapper">
-      <div class="name">{{ userTitle }}</div>
-      <div class="info">{{ userTweetCount }}推文</div>
-    </div>
-    <span v-else class="title">{{ title }}</span>
   </header>
 </template>
 
@@ -38,8 +40,19 @@ const indexRouteName = ["main"];
 const settingRouteName = ["setting"];
 
 export default {
+  props: {
+    isReady: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
   created() {
     const currentRouteName = this.$route.name;
+    const profileRoute = ["userTweets", "replyTweets", "likeTweets"];
+    if (!profileRoute.includes(currentRouteName)) {
+      this.isHeaderReady = true;
+    }
     this.handleTitleByRoute(currentRouteName);
   },
   inject: {
@@ -56,6 +69,8 @@ export default {
       isShowArrow: false,
       isUser: false,
       isSettingLayout: false,
+      isLoading: true,
+      isHeaderReady: false,
     };
   },
   watch: {
@@ -72,6 +87,9 @@ export default {
     },
     title(val) {
       return val;
+    },
+    isReady(val) {
+      this.isHeaderReady = val;
     },
   },
   computed: {
@@ -109,10 +127,9 @@ export default {
 <style lang="scss" scoped>
 header {
   position: fixed;
-  display: flex;
+
   z-index: 999;
-  flex-direction: row;
-  align-items: center;
+
   height: 55px;
   width: 100%;
   padding-left: 15px;
@@ -120,6 +137,12 @@ header {
   border: 1px solid var(--border-stroke-color);
 }
 
+.header-content {
+  display: flex;
+  height: 100%;
+  flex-direction: row;
+  align-items: center;
+}
 .user-wrapper {
   display: block;
   height: 55px;

--- a/src/components/UserProfile.vue
+++ b/src/components/UserProfile.vue
@@ -179,6 +179,8 @@ export default {
       followersCount: this.userData.Followers.length,
       followingsCount: this.userData.Followers.length,
     };
+    this.turnHeaderShow();
+
     next();
   },
   data() {
@@ -186,7 +188,14 @@ export default {
       user: {},
     };
   },
-  inject: ["profileUser"],
+  inject: {
+    profileUser: {
+      from: "profileUser",
+    },
+    turnHeaderShow: {
+      from: "turnHeaderShow",
+    },
+  },
 
   watch: {
     profileUser: {
@@ -196,6 +205,7 @@ export default {
           followersCount: this.userData.Followers.length,
           followingsCount: this.userData.Followers.length,
         };
+        this.turnHeaderShow();
       },
       deep: true,
     },

--- a/src/components/layouts/MainLayout.vue
+++ b/src/components/layouts/MainLayout.vue
@@ -2,7 +2,7 @@
   <div>
     <MobileNavbar />
     <Navbar @openModal="openModal('tweet')" />
-    <Header />
+    <Header :isReady="isHeaderReady" />
     <PopularList />
     <transition name="fade">
       <TweetModal
@@ -37,11 +37,13 @@ export default {
   data() {
     return {
       isRouteAlive: true,
+      isHeaderReady: false,
     };
   },
   provide() {
     return {
       reload: this.reload,
+      turnHeaderShow: this.turnHeaderShow,
     };
   },
   methods: {
@@ -50,6 +52,9 @@ export default {
       this.$nextTick(() => {
         this.isRouteAlive = true;
       });
+    },
+    turnHeaderShow() {
+      this.isHeaderReady = true;
     },
   },
 };

--- a/src/components/layouts/SettingLayout.vue
+++ b/src/components/layouts/SettingLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Navbar @openModal="openModal('tweet')" />
-    <Header />
+    <Header :isReady="true" />
     <transition name="fade">
       <TweetModal
         class="modal"


### PR DESCRIPTION
當進入或是重新整理profile頁時，header都會先出現一個 0推文，使用體驗不好所以將其改善成profile資訊加載完才顯示header資訊。